### PR TITLE
$parsed['undefined'] is null (no more undefined index error)

### DIFF
--- a/CommandLine.php
+++ b/CommandLine.php
@@ -142,7 +142,7 @@ class CommandLine
 
         self::$args                     = $out;
 
-        return $out;
+        return new CommandLineResult($out);
     }
 
     /**
@@ -188,5 +188,56 @@ class CommandLine
         }
 
         return $default;
+    }
+}
+
+class CommandLineResult implements ArrayAccess, countable
+{
+    protected $values = array();
+
+    public function __construct(array $values = array())
+    {
+        $this->values = $values;
+    }
+
+    /**
+    * @return bool
+    */
+    public function offsetExists ($offset)
+    {
+        return array_key_exists($offset, $this->values);
+    }
+
+    /**
+    * @return mixed 
+    */
+    public function offsetGet ($offset)
+    {
+        if(!$this->offsetExists($offset))
+        {
+            return null;
+        }
+        return $this->values[$offset];
+    }
+
+    /**
+    * @return void
+    */
+    public function offsetSet($offset , $value )
+    {
+        $this->values[$offset] = $value;
+    }
+
+    /**
+    * @return void
+    */
+    public function offsetUnset( $offset )
+    {
+        unset($this->values[$offset]);
+    }
+
+    public function count()
+    {
+        return count($this->values);
     }
 }

--- a/tests/CommandLineTest.php
+++ b/tests/CommandLineTest.php
@@ -174,4 +174,11 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $result = CommandLine::parseArgs(array());
         $this->assertEquals(1, count($result));
     }
+
+    /** @test */
+    public function undefinedArg()
+    {
+        $result = CommandLine::parseArgs(array(self::FILE));
+        $this->assertNull($result['doesnotexist']);
+    }
 }


### PR DESCRIPTION
added a result object instead of array.
This object implements arrayAccess + Countable interfaces so it behave as an array, existing code will not break (tests did not break).
Plus we can now request an non existing argument without triggering an `Undefined index` error or having to write like that : `$output = isset($args['output']) ? $args['output'] : null;`
We can now have  `$output = $args['output']` (null). No error, not worry about Undefined index error.
